### PR TITLE
adding metadata to omamer database

### DIFF
--- a/bin/omamer
+++ b/bin/omamer
@@ -21,7 +21,7 @@
     along with OMAmer. If not, see <http://www.gnu.org/licenses/>.
 '''
 from argparse import ArgumentParser, HelpFormatter, _SubParsersAction, FileType
-from omamer._runners import mkdb_oma, search
+from omamer._runners import mkdb_oma, search, info_db
 from omamer import __version__, __copyright__
 from tables import PerformanceWarning
 import logging
@@ -180,6 +180,16 @@ search_parser.add_argument(
     choices=["debug", "info", "warning"],
     help="Logging level.",
 )
+info_parser = subparsers.add_parser(
+    "info",
+    help="Show metadata about an omamer database.",
+    description="Show metadata about an existing omamer database",
+)
+info_parser.set_defaults(func=info_db)
+info_parser.add_argument(
+    "--db", required=True, help="Path to an existing database (including filename)."
+)
+
 
 args = parser.parse_args()
 if hasattr(args, "func"):

--- a/omamer/_runners.py
+++ b/omamer/_runners.py
@@ -60,6 +60,7 @@ def mkdb_oma(args):
     LOG.info('Building index')
     ki = Index(db, k=args.k, reduced_alphabet=args.reduced_alphabet, nthreads=1, hidden_taxa=hidden_taxa)
     ki.build_kmer_table()
+    db.add_metadata()
 
     db.close()
     LOG.info('Done')
@@ -130,3 +131,16 @@ def search(args):
 
     pbar.close()
     db.close()
+
+
+def info_db(args):
+    from .database import Database
+    with Database(args.db) as db:
+        print("=" * 80)
+        for k, v in db.get_metadata().items():
+            if isinstance(v, list):
+                if len(v) == 0:
+                    v = ['-']
+                v = ",".join(v)
+            print(f"  {k:23s}:{v!s:>40}")
+        print("=" * 80)


### PR DESCRIPTION
adding metadata to the omamer database that can be querried with a command line interface

stores all the parameters, OMA version and omamer version used at with mkdb. This addresses an 
issue https://github.com/DessimozLab/OMArk/issues/13 in OMArk where it is unclear what database
has been used.
